### PR TITLE
New OptParameterDistribution to use `Distributions` package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 IMASutils = "b8e4ee59-9bed-3a6a-a553-8dd24d6374ad"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
@@ -14,6 +15,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 AbstractTrees = "0.4"
+Distributions = "0.25.113"
 IMASutils = "1.1.2"
 JSON = "0.21"
 Measurements = "2"

--- a/src/SimulationParameters.jl
+++ b/src/SimulationParameters.jl
@@ -6,6 +6,7 @@ import JSON
 import YAML
 import Measurements: ±, Measurement
 import IMASutils: mirror_bound
+import Distributions
 
 include("parameter.jl")
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
# Summary
This PR introduces a new `OptParameterDistribution` struct that integrates with the `Distributions` package.

By leveraging the diverse distribution functions provided by the `Distributions` package (e.g., Normal distribution), this implementation allows users to generate datasets tailored to their specific needs more effectively.

Note that this PR does not affect anything using the current implementation (safe to merge).
This PR is designed for enhancing the database generation, not for the optimization things, at this moment.


# Issue
The current implementation only supports the Uniform distribution, which might require an excessive number of samples to adequately explore multi-dimensional parametric spaces.

This PR can help users address this limitation by enabling dataset generation that emphasizes the nominal range of parameters rather than overly deviated values. By focusing on the nominal range, the augmented dataset improves representation around the key parameter values, which can ultimately enhance the accuracy of models trained on the nominal set.


# Current feature
Suppose we want to explore different sizes of devices with the major radius (`R0`).
The current parameter supports the `Uniform` sampling as the following example:
```julia
# suppose we already initialized `ini`
ini.equilibrium.R0 = 1.5 ↔ [0.5, 7.0] 
histogram([rand(getfield(ini.equilibrium, :R0)) for _ in 1:1e4]; alpha=0.5, normalize=:pdf, nbins=50, label="Uniform")
xlims!(-2.0, 10.0)
xlabel!("R0")
```
![Screenshot 2024-12-13 at 8 26 15 PM](https://github.com/user-attachments/assets/ea2b3bda-1316-4023-9985-8c0806a9e4ef)


# New feature examples

## 1. Normal distribution (Gaussian)
One can use the `Normal` distribution provided by the `Distributions` package.
```julia
using Distributions
# Use the Normal distribution with (mean=1.5) and (std=1.0)
ini.equilibrium.R0 = 1.5 ↔ Normal(1.5,1.0)
histogram!([rand(getfield(ini.equilibrium, :R0)) for _ in 1:1e4]; alpha=0.5, normalize=:pdf, nbins=50, label="Normal")
```
![Screenshot 2024-12-13 at 8 26 18 PM](https://github.com/user-attachments/assets/29e22bf8-aa72-48a9-9cde-a64e035af276)


## 2. Normal distribution with truncation
In the previous example, it produced the negative `R0` which is non-physical.
One can define some minimum `R0` (and maximum `R0` if wanted) by truncating the given distribution function.
Let's set the minimum `R0=0.5`, such that all samples should be larger than 0.5. 
See the green histogram as the result.
```julia
ini.equilibrium.R0 = 1.5 ↔ truncated(Normal(1.5,1.0), lower=0.5, upper=Inf)
histogram!([rand(getfield(ini.equilibrium, :R0)) for _ in 1:1e4]; alpha=0.5, normalize=:pdf, nbins=50, label="truncated Normal")
```
![Screenshot 2024-12-13 at 8 26 22 PM](https://github.com/user-attachments/assets/5888a718-f53f-41b1-9d1b-570d04b5ba8d)

## 3. Customized distribution
One can customize the distribution by mixing different distributions, which is provided by the `Distributions` package.
For example, we want to sample some small devices (near `R0=1.5`) and some large devices (near `R0=5.0`) at the same time.

```julia
small_device = truncated(Normal(1.5,1.0), lower=0.5, upper=Inf)
large_device = truncated(Normal(5.0,1.0), lower=0.5, upper=Inf)

# Mix the small and large devices in a half-half way
both_devices = MixtureModel([small_device, large_device], [0.5, 0.5])

ini.equilibrium.R0 = 1.5 ↔ both_devices
histogram!([rand(getfield(ini.equilibrium, :R0)) for _ in 1:1e4]; alpha=0.7, normalize=:pdf, nbins=50, label="double Normal")
```
![Screenshot 2024-12-13 at 8 26 28 PM](https://github.com/user-attachments/assets/b710b8c5-7fe4-4957-8fa7-184f5adae71b)


# Validity of the Nominal value
The validity of the nominal value is examined when the `OptParameterDistribution` is created.
There are two cases: error and warning.

## 1. Assertion Error
If the nominal value is not in the supported range of the given distribution, it will raise the `error`.
```julia
# `R0=0.1` is too small and not in the supported range
ini.equilibrium.R0 = 0.1 ↔ truncated(Normal(1.5,1.0), lower=0.5, upper=Inf)
```
![Screenshot 2024-12-13 at 8 26 41 PM](https://github.com/user-attachments/assets/86f6637e-bac0-419a-b735-9598a5c06535)

## 2. Warning
If the nominal value is not in the probable range (5%-95%) of the given distribution, it will warn the user, and then keep going.
```julia
# R0=10 is quite large, so not a good nominal value, but it is anyway supported
ini.equilibrium.R0 = 10.0 ↔ truncated(Normal(1.5,1.0), lower=0.5, upper=Inf)
```
![Screenshot 2024-12-13 at 8 26 53 PM](https://github.com/user-attachments/assets/aba3204b-b4dd-4a8f-bdcb-6e2171de67e0)


# NOTE
[v] tests are added and passed.
 
