### PR TITLE
Bugfix for hdf2par Function

### DIFF
--- a/src/SimulationParameters.jl
+++ b/src/SimulationParameters.jl
@@ -37,6 +37,7 @@ export par2jstr, jstr2par
 export par2ystr, ystr2par
 export par2json, json2par
 export par2yaml, yaml2par
+export par2hdf, hdf2par
 export show_modified
 export OptParameter, ↔, opt_parameters, parameters_from_opt!, rand, rand!, float_bounds, nominal_values, opt_labels
 export InexistentParametersFieldException, NotsetParameterException, BadParameterException

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,6 +1,6 @@
-# ==== # 
+# ==== #
 # YAML #
-# ==== # 
+# ==== #
 
 function par2ystr(par::AbstractParameters; show_info::Bool=true, skip_defaults::Bool=false)
     tmp = par2ystr(par, String[]; show_info, skip_defaults)
@@ -188,9 +188,9 @@ function yaml2par(filename::AbstractString, par::AbstractParameters)
     end
 end
 
-# ==== # 
+# ==== #
 # JSON #
-# ==== # 
+# ==== #
 
 """
     par2json(@nospecialize(par::AbstractParameters), filename::String; kw...)
@@ -313,7 +313,7 @@ function dict2par!(dct::AbstractDict, par::AbstractParameters)
             catch e
                 println(stderr, "Error setting parameter $(spath(parameter))::$(eltype(parameter)) with: `$(value)`::$(typeof(value))")
                 rethrow(e)
-            end                
+            end
         end
     end
     return par
@@ -373,11 +373,6 @@ function par2hdf!(@nospecialize(par::AbstractParametersVector), gparent::Union{H
     end
 end
 
-function hdf2par(@nospecialize(par::AbstractParameters), filename::String; kw...)
-    HDF5.h5open(filename, "w"; kw...) do fid
-        return par2hdf!(par, fid)
-    end
-end
 
 """
     hdf2par(filename::AbstractString, par::AbstractParameters; kw...)
@@ -481,7 +476,11 @@ function string_decode_value(par::AbstractParameters, field::Symbol, value::Any)
             etp = eltype(tp)
         end
         if !isempty(value)
-            value = etp.(value)
+            if tp <: AbstractArray{Symbol} && typeof(value) <: AbstractArray{String}
+                value = Symbol.([(startswith(x, ":") ? x[2:end] : x) for x in value ])
+            else
+                value = etp.(value)
+            end
         else
             value = Vector{etp}()
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,19 @@ end
     @test diff(ini, ini2) === false
 end
 
+@testset "hdf_save_load" begin
+    ini = ParametersInits()
+
+    tmp_hdf_filename = tempname()
+    par2hdf(ini, tmp_hdf_filename)
+
+    ini2 = hdf2par(tmp_hdf_filename, ParametersInits())
+
+    @test diff(ini, ini2) === false
+
+    isfile(tmp_hdf_filename) && rm(tmp_hdf_filename)
+end
+
 @testset "checks" begin
     ini = ParametersInits()
 


### PR DESCRIPTION
## Summary
This PR addresses a bug in the `string_decode_value` function when the target data type (`tp`) is a `Vector{Symbol}`.

## Example of Issue
In the following `ParametersInits` example, the previous implementation of `hdf2par` reads the field  
`a_vector_symbol{Vector{Symbol}} ➡ [:hello, :world]` and produced an incorrect result of  
`[Symbol(":hello"), Symbol(":world")]`, whereas the correct result should be `[:hello, :world]`.
```julia
ParametersInits
├─ time
│  ├─ pulse_shedule_time_basis{AbstractRange{Float64}} ➡ missing Time basis used to discretize the pulse schedule
│  └─ simulation_start{Float64} ➡ 0.0 [s] Time at which the simulation starts
└─ equilibrium
   ├─ R0{Float64} ➡ missing Geometric center of the plasma
   ├─ casename{String} ➡ missing Mnemonic name of the case being run
   ├─ init_from{Symbol} ➡ missing Initialize run from [:ods, :scalars, :my_own]
   ├─ dict_option{Int64} ➡ missing My switch with SwitchOption [2, 3, 1]
   ├─ a_symbol{Symbol} ➡ :hello something
   ├─ a_vector_symbol{Vector{Symbol}} ➡ [:hello, :world] something symbol vector
   ├─ b_vector_float{Vector{Float64}} ➡ [0.1, 0.2, 0.3] something float64 vector
   └─ v_params
```
 ### Real example in FUSE
`ActorPlasmaLimits.model` was the issue.
```julia
act.ActorPlasmaLimits
ActorPlasmaLimits
├─ models{Vector{Symbol}} ➡ [:vertical_stability, :beta_troyon_nn, :q95_gt_2, :gw_density, :κ_controllability] Models used
│  for checking plasma operational limits: [:vertical_stability, :beta_troyon_nn, :beta_troyon_1984, :beta_troyon_1985,
│  :beta_tuda_1985, :beta_bernard_1983, :beta_betali_a, :q95_gt_2, :q80_gt_2, :gw_density, :κ_controllability]
├─ raise_on_breach{Bool} ➡ true Raise an error when one or more operational limits are breached
└─ verbose{Bool} ➡ false Verbose
```


## Changes
- Fixed the `hdf2par` function to correctly read and convert `Vector{Symbol}` data.

## Testing
- Unit test was added to verify the correct functionality of the `hdf2par` function.
