### PR TITLE
Fix diff() erroring on NaN parameter values; fix vector diff comparing p1 to itself

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationParameters"
 uuid = "32ab26d3-25d6-405d-a295-367385e16093"
 authors = ["Orso Meneghini <orso82@gmail.com>"]
-version = "2.1.4"
+version = "2.1.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimulationParameters"
 uuid = "32ab26d3-25d6-405d-a295-367385e16093"
 authors = ["Orso Meneghini <orso82@gmail.com>"]
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/io.jl
+++ b/src/io.jl
@@ -13,15 +13,8 @@ function par2ystr(par::AbstractParametersVector, txt::Vector{String}; show_info:
     end
 end
 
-function equals_with_missing(a, b)
-    if ismissing(a) && ismissing(b)
-        return true
-    elseif ismissing(a) || ismissing(b)
-        return false
-    else
-        return a == b
-    end
-end
+# isequal treats missing==missing and NaN==NaN as true, unlike ==
+equals_with_missing(a, b) = isequal(a, b)
 
 function YAML._print(io::IO, value::Missing, level::Int=0, ignore_level::Bool=false)
     return println(io, "~")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,7 +41,7 @@ function Base.diff(p1::AbstractParametersVector, p2::AbstractParametersVector)
     end
     for key in commonkeys
         v1 = p1[key]
-        v2 = p1[key]
+        v2 = p2[key]
         if typeof(v1) !== typeof(v2)
             error("$key is of different type")
         elseif typeof(v1) <: AbstractParameters


### PR DESCRIPTION
## Problem

FUSE CI (`test/runtests_study.jl`) started failing after ProjectTorreyPines/FUSE.jl#1124 added `ActorSOLPSNN.Psol` with `default=NaN`:

```
Psol had different value:
act.ActorSOLPSNN.Psol ... value: NaN
act.ActorSOLPSNN.Psol ... value: NaN
```

`diff()` compares values through `equals_with_missing`, which fell through to `a == b`. Since `NaN == NaN` is `false`, two identical NaN values were reported as different and `diff` errored.

(FUSE side is independently fixed by ProjectTorreyPines/FUSE.jl#1138, which drops the NaN sentinel — this PR remains worthwhile as a robustness fix: parameter values can legitimately contain NaN, e.g. inside arrays.)

## Fix

- `equals_with_missing(a, b) = isequal(a, b)` — `isequal` treats `missing == missing` and `NaN == NaN` as true (including inside arrays), and otherwise matches `==`.
- Fix a copy-paste bug in `diff(::AbstractParametersVector, ...)`: `v2` was read from `p1` instead of `p2`, so vector-parameter diffs silently compared `p1` against itself.

### Note on the `src/io.jl` call site

`equals_with_missing` is also used in `par2ystr`'s `skip_defaults` sub-tree check. The scalar-parameter path below it already uses `value === default`, and for floats `===` treats `NaN === NaN` as true and `-0.0 === 0.0` as false. The old `==`-based check diverged from that on exactly those two cases (an untouched NaN-defaulted parameter was wrongly considered "not default" and written out); `isequal` matches `===` float semantics, so this change aligns the sub-tree check with the existing scalar check.

## Testing

- Targeted check: NaN-defaulted `Entry` diffs cleanly, real differences still throw, missing/NaN-array semantics correct.
- Full `Pkg.test()` suite passes.

Version bump to be done after merge per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)